### PR TITLE
Change name of process to avoid conflicts between the global  usage

### DIFF
--- a/src/change.ts
+++ b/src/change.ts
@@ -311,9 +311,9 @@ export class ChangeSet extends ChangeDesc {
       total = total ? total.compose(set.map(total)) : set
       sections = []; inserted = []; pos = 0
     }
-    function process(spec: ChangeSpec) {
+    function _process(spec: ChangeSpec) {
       if (Array.isArray(spec)) {
-        for (let sub of spec) process(sub)
+        for (let sub of spec) _process(sub)
       } else if (spec instanceof ChangeSet) {
         if (spec.length != length)
           throw new RangeError(`Mismatched change set length (got ${spec.length}, expected ${length})`)
@@ -334,7 +334,7 @@ export class ChangeSet extends ChangeDesc {
       }
     }
 
-    process(changes)
+    _process(changes)
     flush(!total)
     return total!
   }


### PR DESCRIPTION
Hello, I'm using rollup and a svelte app where I inject some environment specific data into my codebase. When rollup is bundling it displays an error similar to this ... 

```[!] Error: Unexpected token
node_modules/@codemirror/state/dist/index.js (345:17)
343:             pos = 0;
344:         }
345:         function process(spec) {
                      ^
346:             if (Array.isArray(spec)) {
347:                 for (let sub of spec)
Error: Unexpected token
```

The root problem is a collision being detected in the function process. 