### PR TITLE
Add exports.types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "main": "dist/index.cjs",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
Resolves https://github.com/codemirror/dev/issues/891

Codemirror is not able to compile since TypeScript 4.7 with `"moduleResolution": "node16"` enabled, because it is unable to find `types` associated with the ESM export, `./dist/index.js`. This PR adds the proper `types` export, which should be backwards compatible with both Node and TS runtimes.

More context on that [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing) and [here](https://github.com/microsoft/TypeScript/issues/49160#issuecomment-1137482639).

I'm happy to submit PRs to all the other repos if this approach works. Thanks for the consideration!